### PR TITLE
Install Imagemagick for WordPress 4.7

### DIFF
--- a/provision/playbook.yml
+++ b/provision/playbook.yml
@@ -17,6 +17,7 @@
       - curl
       - gettext
       - python-mysqldb
+      - imagemagick
 
   # Apache2
   - name: Ensure apache is installed
@@ -61,6 +62,7 @@
       - php7.0-curl
       - php7.0-zip
       - php-xdebug
+      - php-imagick
     notify: restart-apache
 
   # Ruby

--- a/spec/default/middleware_spec.rb
+++ b/spec/default/middleware_spec.rb
@@ -68,6 +68,7 @@ commands = %w{
   msgfmt
   msgmerge
   svn
+  convert
 }
 
 commands.each do |commands|


### PR DESCRIPTION
https://make.wordpress.org/core/2016/11/15/enhanced-pdf-support-4-7/

requires Imagick, ImageMagick, and Ghostscript support for creating PDF thumbnail.

Ghostscript is installed in on ImageMagick install.  ( https://launchpad.net/ubuntu/xenial/+source/imagemagick )