### PR TITLE
Update image and package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 MAINTAINER "vccw-team"
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "bento/ubuntu-16.04"
+  config.vm.box = "bento/ubuntu-18.04"
   config.ssh.insert_key = false
   config.vbguest.auto_update = true
   config.vm.box_check_update = true

--- a/provision/playbook.yml
+++ b/provision/playbook.yml
@@ -25,10 +25,10 @@
       - python-mysqldb
       - imagemagick
       - net-tools
-      - ruby2.4
-      - ruby2.4-dev
+      - ruby2.7
+      - ruby2.7-dev
       - software-properties-common
-      - python-software-properties
+      - python3-software-properties
 
   # Apache2
   - name: Ensure apache is installed
@@ -62,24 +62,23 @@
   - name: Install PHP packages
     apt: name={{ item }} state=latest update_cache=yes
     with_items:
-      - php7.0
-      - libapache2-mod-php7.0
-      - php7.0-cli
-      - php7.0-dev
-      - php7.0-mbstring
-      - php7.0-mcrypt
-      - php7.0-mysql
-      - php7.0-gd
-      - php7.0-curl
-      - php7.0-zip
-      - php7.0-xml
+      - php7.4
+      - libapache2-mod-php7.4
+      - php7.4-cli
+      - php7.4-dev
+      - php7.4-mbstring
+      - php7.4-mysql
+      - php7.4-gd
+      - php7.4-curl
+      - php7.4-zip
+      - php7.4-xml
       - php-xdebug
       - php-imagick
     notify: restart-apache
 
   # Node.js
   - name: Install Node.js PPM
-    shell: curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+    shell: curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
   - name: Install Node.js
     apt: name=nodejs state=latest
 

--- a/spec/default/middleware_spec.rb
+++ b/spec/default/middleware_spec.rb
@@ -51,7 +51,7 @@ end
 describe command('node -v') do
   let(:disable_sudo) { true }
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match /v6\./ }
+  its(:stdout) { should match /v12\./ }
 end
 
 describe command('ruby -v') do
@@ -71,16 +71,16 @@ packages = %w{
   gettext
   python-mysqldb
   imagemagick
-  php7.0
-  libapache2-mod-php7.0
-  php7.0-cli
-  php7.0-dev
-  php7.0-mbstring
-  php7.0-mcrypt
-  php7.0-mysql
-  php7.0-gd
-  php7.0-curl
-  php7.0-zip
+  php7.4
+  libapache2-mod-php7.4
+  php7.4-cli
+  php7.4-dev
+  php7.4-mbstring
+  php7.4-mcrypt
+  php7.4-mysql
+  php7.4-gd
+  php7.4-curl
+  php7.4-zip
   php-xdebug
   php-imagick
 }


### PR DESCRIPTION
## Ubuntu

The latest LTS version of Ubuntu is 20.04, but since the ppa repository doesn't include ansible, I use the previous LTS, 18.04.

## Node

The latest version of Node is 14.x, but webpack (which depends on chokidar 2) doesn't work on Node 14.x, so install Node 12.x.
